### PR TITLE
molecule-vagrant: Add python-pip to makedepends

### DIFF
--- a/molecule-vagrant/trunk/PKGBUILD
+++ b/molecule-vagrant/trunk/PKGBUILD
@@ -9,8 +9,7 @@ arch=('any')
 url="https://github.com/ansible-community/molecule-vagrant"
 license=('MIT')
 depends=('python' 'ansible' 'molecule' 'python-pyaml' 'python-vagrant')
-makedepends=('python-setuptools' 'python-setuptools-scm' 'molecule'
-'python-vagrant' 'python-pyaml')
+makedepends=('python-setuptools' 'python-setuptools-scm' 'python-pip')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/ansible-community/molecule-vagrant/archive/${pkgver}.tar.gz")
 sha512sums=('8da5d444925d8dcb35abcaccb7b6f8e23492a61c5dd05a4cfd129801577b3df76cca87d8abccc1580742727b42f133731ab4720a13a3c553c3163957fb42df47')
 


### PR DESCRIPTION
Without `python-pip` building package fails with:

```
/usr/bin/python: No module named pip
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/setuptools/installer.py", line 75, in fetch_build_egg
    subprocess.check_call(cmd)
  File "/usr/lib/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/usr/bin/python', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmp4vj7xsvi', '--quiet', 'setuptools_scm_git_archive>=1.0']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/path/to/pkgbuilds/molecule-vagrant/trunk/src/molecule-vagrant-0.2/setup.py", line 6, in <module>
    setuptools.setup(use_scm_version=True)
  File "/usr/lib/python3.9/site-packages/setuptools/__init__.py", line 152, in setup
    _install_setup_requires(attrs)
  File "/usr/lib/python3.9/site-packages/setuptools/__init__.py", line 147, in _install_setup_requires
    dist.fetch_build_eggs(dist.setup_requires)
  File "/usr/lib/python3.9/site-packages/setuptools/dist.py", line 785, in fetch_build_eggs
    resolved_dists = pkg_resources.working_set.resolve(
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 766, in resolve
    dist = best[req.key] = env.best_match(
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 1051, in best_match
    return self.obtain(req, installer)
  File "/usr/lib/python3.9/site-packages/pkg_resources/__init__.py", line 1063, in obtain
    return installer(requirement)
  File "/usr/lib/python3.9/site-packages/setuptools/dist.py", line 844, in fetch_build_egg
    return fetch_build_egg(self, req)
  File "/usr/lib/python3.9/site-packages/setuptools/installer.py", line 77, in fetch_build_egg
    raise DistutilsError(str(e)) from e
distutils.errors.DistutilsError: Command '['/usr/bin/python', '-m', 'pip', '--disable-pip-version-check', 'wheel', '--no-deps', '-w', '/tmp/tmp4vj7xsvi', '--quiet', 'setuptools_scm_git_archive>=1.0']' returned non-zero exit status 1.
==> ERROR: A failure occurred in build().
```

Also python-vagrant, molecule, python-pyaml are already in depends

https://wiki.archlinux.org/title/PKGBUILD#makedepends:
The packages in the depends array are implicitly required to build the package, they should not be duplicated here.